### PR TITLE
Set the dedicated status of the sidebar window

### DIFF
--- a/frame-purpose.el
+++ b/frame-purpose.el
@@ -159,7 +159,7 @@ is a symbol, one of left, right, top, or bottom."
                  ('below nil)))
          (size (pcase side
                  ((or 'left 'right)
-                  (apply #'max (--map (+ 3 (length (buffer-name)))
+                  (apply #'max (--map (+ 3 (length (buffer-name it)))
                                       (buffer-list))))
                  ((or 'nil 'below)
                   1))))

--- a/frame-purpose.el
+++ b/frame-purpose.el
@@ -164,7 +164,8 @@ is a symbol, one of left, right, top, or bottom."
                  ((or 'nil 'below)
                   1))))
     (split-window nil size side)
-    (switch-to-buffer (frame-purpose--sidebar-name))))
+    (switch-to-buffer (frame-purpose--sidebar-name))
+    (set-window-dedicated-p (selected-window) t)))
 
 ;;;; Functions
 


### PR DESCRIPTION
This prevents another buffer from being displayed in the sidebar window by `*-other-window` operation.

This PR includes two commits by mistake. If necessary, I will recreate a new PR that includes only the last commit.