### PR TITLE
Fix

### DIFF
--- a/frame-purpose.el
+++ b/frame-purpose.el
@@ -213,7 +213,8 @@ passed as frame parameters to `make-frame', which see."
                                              `(frame-purpose--check-mode ',modes))
                                           ,(when filenames
                                              `(cl-loop for filename in ',filenames
-                                                       when default-directory)))))))))
+                                                       when default-directory
+                                                       thereis (string-match filename default-directory))))))))))
     ;; Validate args
     (unless (or modes filenames (map-elt parameters 'buffer-predicate))
       (user-error "One of `:modes', `:filenames', or `:buffer-predicate' must be set"))


### PR DESCRIPTION
Somehow this part was lost at https://github.com/alphapapa/frame-purpose.el/commit/59cfb00015e6d6ea45610f02f7343efab2889038 so I restored it.

I still feel a bit strange, because the values are matched against `default-directory` of the buffer rather than `(buffer-file-name)`. It does not follow the specification in the docstring, doesn't it? (See #11 which attempts to fix this)