### PR TITLE
Check against the buffer file name

### DIFF
--- a/frame-purpose.el
+++ b/frame-purpose.el
@@ -213,7 +213,8 @@ passed as frame parameters to `make-frame', which see."
                                              `(frame-purpose--check-mode ',modes))
                                           ,(when filenames
                                              `(cl-loop for filename in ',filenames
-                                                       when default-directory)))))))))
+                                                       when default-directory
+                                                       thereis (string-match filename default-directory))))))))))
     ;; Validate args
     (unless (or modes filenames (map-elt parameters 'buffer-predicate))
       (user-error "One of `:modes', `:filenames', or `:buffer-predicate' must be set"))

--- a/frame-purpose.el
+++ b/frame-purpose.el
@@ -213,8 +213,8 @@ passed as frame parameters to `make-frame', which see."
                                              `(frame-purpose--check-mode ',modes))
                                           ,(when filenames
                                              `(cl-loop for filename in ',filenames
-                                                       when default-directory
-                                                       thereis (string-match filename default-directory))))))))))
+                                                       when buffer-file-name
+                                                       thereis (string-match filename buffer-file-name))))))))))
     ;; Validate args
     (unless (or modes filenames (map-elt parameters 'buffer-predicate))
       (user-error "One of `:modes', `:filenames', or `:buffer-predicate' must be set"))


### PR DESCRIPTION
This is a follow-up to #9. It checks the buffer file name rather than the default directory. 