### PR TITLE
Fix: Expand the directory and regexp-quote it

### DIFF
--- a/frame-purpose.el
+++ b/frame-purpose.el
@@ -123,7 +123,7 @@ but it should help)."
   "Make a purpose-specific frame for buffers associated with DIRECTORY.
 DIRECTORY defaults to the current buffer's directory."
   (interactive (list default-directory))
-  (frame-purpose-make-frame :filenames directory
+  (frame-purpose-make-frame :filenames (regexp-quote (expand-file-name directory))
                             :title (file-name-nondirectory (directory-file-name directory))))
 
 ;;;###autoload


### PR DESCRIPTION
- Whether `buffer-file-name` or `default-directory` you use to test against the predicate, it is a non-abbreviated path, so `expand-file-name` is required if the given directory is abbreviated. For example, `(frame-purpose-make-directory-frame user-emacs-directory)` didn't work in the former implementation.
- Because `:filenames` is tested using `string-match`, it will be safer to escape the directory path.